### PR TITLE
add .gitattributes to enable Solidity syntax highlight on GitHub

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sol linguist-language=Solidity


### PR DESCRIPTION
This commit adds syntax highlighting for Solidity code on GitHub.

After merging and waiting several hours, you will see that the codes are highlighted on GitHub.