### PR TITLE
Blockchain Masterclass: Update transfers usage.

### DIFF
--- a/blockchain-masterclass/wallet-1-smart-contract/4-get-list-of-transfers.sol
+++ b/blockchain-masterclass/wallet-1-smart-contract/4-get-list-of-transfers.sol
@@ -11,7 +11,7 @@ contract Wallet {
     uint approvals;
     bool sent;
   }
-  mapping(uint => Transfer) public transfers;
+  Transfer[] public transfers;
 
   constructor(address[] memory _approvers, uint _quorum) public {
     approvers = _approvers;

--- a/blockchain-masterclass/wallet-1-smart-contract/4-get-list-of-transfers.sol
+++ b/blockchain-masterclass/wallet-1-smart-contract/4-get-list-of-transfers.sol
@@ -33,6 +33,6 @@ contract Wallet {
       to,
       0,
       false
-    );
+    ));
   }
 }

--- a/blockchain-masterclass/wallet-1-smart-contract/5-approve-transfers.sol
+++ b/blockchain-masterclass/wallet-1-smart-contract/5-approve-transfers.sol
@@ -11,7 +11,7 @@ contract Wallet {
     uint approvals;
     bool sent;
   }
-  mapping(uint => Transfer) public transfers;
+  Transfer[] public transfers;
   mapping(address => mapping(uint => bool)) public approvals;
 
   constructor(address[] memory _approvers, uint _quorum) public {

--- a/blockchain-masterclass/wallet-1-smart-contract/6-send-ether-to-wallet.sol
+++ b/blockchain-masterclass/wallet-1-smart-contract/6-send-ether-to-wallet.sol
@@ -11,7 +11,7 @@ contract Wallet {
     uint approvals;
     bool sent;
   }
-  mapping(uint => Transfer) public transfers;
+  Transfer[] public transfers;
   mapping(address => mapping(uint => bool)) public approvals;
 
   constructor(address[] memory _approvers, uint _quorum) public {

--- a/blockchain-masterclass/wallet-1-smart-contract/7-access-control.sol
+++ b/blockchain-masterclass/wallet-1-smart-contract/7-access-control.sol
@@ -34,7 +34,7 @@ contract Wallet {
       to,
       0,
       false
-    );
+    ));
   }
 
   function approveTransfer(uint id) external onlyApprover() {

--- a/blockchain-masterclass/wallet-1-smart-contract/7-access-control.sol
+++ b/blockchain-masterclass/wallet-1-smart-contract/7-access-control.sol
@@ -11,7 +11,7 @@ contract Wallet {
     uint approvals;
     bool sent;
   }
-  mapping(uint => Transfer) public transfers;
+  Transfer[] public transfers;
   mapping(address => mapping(uint => bool)) public approvals;
 
   constructor(address[] memory _approvers, uint _quorum) public {


### PR DESCRIPTION
This PR corrects the type of the `transfers` field, which went from a mapping to an array in the "Get list of transfers" video.

Some missing brackets in `transfers.push()` calls are fixed as well.