### PR TITLE
fix: bug safeTransferFrom(address,address,uint256) charge royalty twice

### DIFF
--- a/screencast/379-nft-royalties/contracts/NFT.sol
+++ b/screencast/379-nft-royalties/contracts/NFT.sol
@@ -46,9 +46,6 @@ contract NFT is ERC721 {
     address to,
     uint256 tokenId
    ) public override {
-     if(excludedList[from] == false) {
-       _payTxFee(from);
-     }
      safeTransferFrom(from, to, tokenId, '');
    }
 

--- a/screencast/379-nft-royalties/test/nft.js
+++ b/screencast/379-nft-royalties/test/nft.js
@@ -118,4 +118,57 @@ describe('NFT', async () =>  {
     await expect(nft.setExcluded(owner2.address, true))
       .to.be.revertedWith('artist only');
   });
+
+  it('Safe Transfer From', async () => {
+    let ownerNFT, balanceSender, balanceArtist;
+
+    nft =  nft.connect(artist);
+    await nft.transferFrom(
+      artist.address, 
+      owner1.address, 
+      0
+    );
+    ownerNFT = await nft.ownerOf(0)
+    expect(ownerNFT)
+      .to
+      .equal(owner1.address);
+    await token.connect(owner1).approve(nft.address, txFee);  
+    await nft.connect(owner1)['safeTransferFrom(address,address,uint256)'](
+      owner1.address, 
+      owner2.address, 
+      0
+    );
+    ownerNFT = await nft.ownerOf(0);
+    balanceSender = await token.balanceOf(owner1.address);
+    balanceArtist = await token.balanceOf(artist.address);
+    expect(ownerNFT)
+      .to
+      .equal(owner2.address);
+    expect(balanceSender.toString())
+      .to
+      .equal(ethers.utils.parseUnits('499', 'ether'));
+    expect(balanceArtist.toString())
+      .to
+      .equal(ethers.utils.parseUnits('1', 'ether'));
+
+    await token.connect(owner2).approve(nft.address, txFee);
+    await nft.connect(owner2)['safeTransferFrom(address,address,uint256,bytes)'](
+      owner2.address, 
+      owner1.address, 
+      0,
+      [1,2,3]
+    );
+    ownerNFT = await nft.ownerOf(0);
+    balanceSender = await token.balanceOf(owner1.address);
+    balanceArtist = await token.balanceOf(artist.address);
+    expect(ownerNFT)
+      .to
+      .equal(owner1.address);
+    expect(balanceSender.toString())
+      .to
+      .equal(ethers.utils.parseUnits('499', 'ether'));
+    expect(balanceArtist.toString())
+      .to
+      .equal(ethers.utils.parseUnits('2', 'ether'));
+  });
 });


### PR DESCRIPTION
Dear EatTheBlocks

I notice a little bug in the royalty contract example that will charge the royalty fee twice.
So I fix it and add the test code. Then create this PR.

P.S. I really appreciate you for making these videos.