### PR TITLE
Bugfix to be able to withdraw after token release

### DIFF
--- a/smart-contract-30/day22-ICO/ICO.sol
+++ b/smart-contract-30/day22-ICO/ICO.sol
@@ -145,6 +145,7 @@ contract ICO {
         onlyAdmin()
         icoEnded()
         tokensNotReleased() {
+        released = true;
         ERC20Token tokenInstance = ERC20Token(token);
         for(uint i = 0; i < sales.length; i++) {
             Sale storage sale = sales[i];


### PR DESCRIPTION
updated the `release` boolean accordingly.

The modifiers `tokensNotReleased` and `tokensReleased`, work accordingly now therefore the `withdraw()` is callable only after the release function was called.